### PR TITLE
fixed broken import with represent>=2.0

### DIFF
--- a/orbital/bodies.py
+++ b/orbital/bodies.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 from __future__ import absolute_import, division, print_function
 
-from represent import RepresentationMixin
+from represent import autorepr
 
 from . import constants as oc
 
@@ -16,8 +16,8 @@ __all__ = [
     'neptune',
 ]
 
-
-class Body(RepresentationMixin, object):
+@autorepr
+class Body(object):
     r"""Reference body for a Keplerian orbit.
 
     :param float mass: Mass (:math:`m`) [kg]
@@ -70,7 +70,7 @@ class Body(RepresentationMixin, object):
             self._periapsis_names = value
 
     def __repr__(self):
-        # Intercept __repr__ from RepresentationMixin to
+        # Intercept __repr__ from autorepr to
         # use orbital.bodies.<planet> for the defaults.
         if __name__ == 'orbital.bodies':
             for name, instance in _defaults.items():
@@ -79,7 +79,7 @@ class Body(RepresentationMixin, object):
         return super(Body, self).__repr__()
 
     def _repr_pretty_(self, p, cycle):
-        # Intercept _repr_pretty_ from RepresentationMixin to
+        # Intercept _repr_pretty_ from autorepr to
         # use orbital.bodies.<planet> for the defaults.
         if __name__ == 'orbital.bodies':
             for name, instance in _defaults.items():

--- a/orbital/elements.py
+++ b/orbital/elements.py
@@ -9,7 +9,7 @@ import sgp4.io
 import sgp4.propagation
 from astropy import time
 from numpy import arctan, cos, degrees, sin, sqrt
-from represent import ReprMixin
+from represent import autorepr
 from scipy.constants import kilo, pi
 from sgp4.earth_gravity import wgs72
 
@@ -24,8 +24,8 @@ __all__ = [
     'KeplerianElements',
 ]
 
-
-class KeplerianElements(ReprMixin, object):
+@autorepr
+class KeplerianElements(object):
 
     """Defines an orbit using keplerian elements.
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ DESCRIPTION = metadata['description']
 
 AUTHOR, EMAIL = re.match(r'(.*) <(.*)>', AUTHOR_EMAIL).groups()
 
-requires = ['numpy', 'scipy', 'astropy', 'matplotlib', 'represent>=1.3.0',
+requires = ['numpy', 'scipy', 'astropy', 'matplotlib', 'represent>=1.5.0',
             'sgp4']
 
 


### PR DESCRIPTION
Resolves #28 

Fixes error when trying to import RepresentationMixin in bodies.py and ReprMixIn in elements.py when using represent>=2.0 by replacing them with the autorepr class decorator.

Does have the side effect of requiring represent>=1.5 as this is when the autorepr class decorator was added. 