### PR TITLE
Fixed Plotter2D animation failing with RuntimeError.

### DIFF
--- a/orbital/plotting.py
+++ b/orbital/plotting.py
@@ -108,8 +108,8 @@ class Plotter2D():
 
         def animate(i):
             orbit.t = times[i - 1]
-            pos = fpos(orbit.f)
-            self.pos_dot.set_data(pos[0], pos[1])
+            x, y, _ = fpos(orbit.f)
+            self.pos_dot.set_data([x], [y])
 
             return self.pos_dot
 


### PR DESCRIPTION
Was failing in Matplotlib with "RuntimeError: x must be a sequence".

Now stores animation data as singleton arrays rather than scalar values. This is consistent with the already-correct Plotter3D.

Fixes #33.