### PR TITLE
docs: Describe how to setup and run tests in a venv.

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -28,11 +28,29 @@ Check out a `release tag <https://github.com/RazerM/orbital/releases>`_:
 	$ cd orbital
 	$ git checkout |version|
 
-Test and install:
+Test and run in a venv:
 
 .. code-block:: sh
 
-	$ python setup.py test
-	running test...
+	$ python -m venv venv
+	$ venv/bin/pip install numpy scipy astropy matplotlib represent sgp4 pytest
+	# Without installing (just runs the code from the source dir):
+	# Run tests:
+	$ PYTHONPATH=. venv/bin/pytest
+	# Run a script that uses the library:
+	$ PYTHONPATH=. venv/bin/python <script>
+
+	# Installing into the venv:
+	$ venv/bin/pip install setuptools
+	$ venv/bin/python setup.py install
+	# Run tests (must run install every time code changes):
+	$ venv/bin/pytest
+	# Run a script that uses the library:
+	$ venv/bin/python <script>
+
+Install to system:
+
+.. code-block:: sh
+
 	$ python setup.py install
 	running install...


### PR DESCRIPTION
Updates the setup documentation to explain how to run, install and test inside a Python venv.

The previous instruction of running `setup.py test` does not seem to run any tests.

Fixes #31.